### PR TITLE
Feat: adds the counterfeit report contract file

### DIFF
--- a/secure-stamp/Clarinet.toml
+++ b/secure-stamp/Clarinet.toml
@@ -15,6 +15,11 @@ path = 'contracts/SupplyChainContract.clar'
 clarity_version = 2
 epoch = 2.5
 
+[contracts.counterfeit-reporter]
+path = 'contracts/counterfeit-reporter.clar'
+clarity_version = 3
+epoch = 3.0
+
 [contracts.product-contract]
 path = 'contracts/product-contract.clar'
 clarity_version = 2

--- a/secure-stamp/contracts/counterfeit-reporter.clar
+++ b/secure-stamp/contracts/counterfeit-reporter.clar
@@ -1,0 +1,147 @@
+
+;; title: counterfeit-reporter
+;; version:
+;; summary:
+;; description:
+
+;; Define constants
+(define-constant contract-owner tx-sender)
+(define-constant reward-amount u100000) ;; in micro-STX (0.1 STX)
+
+;; Define error codes
+(define-constant err-unauthorized (err u100))
+(define-constant err-already-reported (err u101))
+(define-constant err-not-reported (err u102))
+(define-constant err-already-verified (err u103))
+(define-constant err-not-verified (err u104))
+(define-constant err-already-claimed (err u105))
+(define-constant err-insufficient-balance (err u106))
+
+;; Define data maps
+(define-map reports 
+  { product-id: (string-ascii 64) }
+  { reporter: principal, verified: bool, claimed: bool }
+)
+
+(define-map user-rewards
+  { user: principal }
+  { balance: uint }
+)
+
+;; Define public functions
+
+;; Function to report a counterfeit product
+(define-public (report-counterfeit (product-id (string-ascii 64)))
+  (let ((existing-report (get reporter (map-get? reports { product-id: product-id }))))
+    (if (is-some existing-report)
+      err-already-reported
+      (begin
+        (map-set reports 
+          { product-id: product-id }
+          { reporter: tx-sender, verified: false, claimed: false }
+        )
+        (ok true)
+      )
+    )
+  )
+)
+
+;; Function to verify a report (only contract owner can verify)
+(define-public (verify-report (product-id (string-ascii 64)))
+  (let ((report (map-get? reports { product-id: product-id })))
+    (if (is-eq tx-sender contract-owner)
+      (if (is-some report)
+        (if (get verified (unwrap-panic report))
+          err-already-verified
+          (begin
+            (map-set reports 
+              { product-id: product-id }
+              (merge (unwrap-panic report) { verified: true })
+            )
+            (ok true)
+          )
+        )
+        err-not-reported
+      )
+      err-unauthorized
+    )
+  )
+)
+
+;; Function to claim a reward
+(define-public (claim-reward (product-id (string-ascii 64)))
+  (let (
+    (report (map-get? reports { product-id: product-id }))
+    (user-reward (default-to { balance: u0 } (map-get? user-rewards { user: tx-sender })))
+  )
+    (if (is-some report)
+      (let ((unwrapped-report (unwrap-panic report)))
+        (if (is-eq (get reporter unwrapped-report) tx-sender)
+          (if (get verified unwrapped-report)
+            (if (not (get claimed unwrapped-report))
+              (begin
+                (map-set reports 
+                  { product-id: product-id }
+                  (merge unwrapped-report { claimed: true })
+                )
+                (map-set user-rewards
+                  { user: tx-sender }
+                  { balance: (+ (get balance user-reward) reward-amount) }
+                )
+                (ok true)
+              )
+              err-already-claimed
+            )
+            err-not-verified
+          )
+          err-unauthorized
+        )
+      )
+      err-not-reported
+    )
+  )
+)
+
+;; Function to withdraw rewards
+(define-public (withdraw-rewards (amount uint))
+  (let (
+    (user-reward (default-to { balance: u0 } (map-get? user-rewards { user: tx-sender })))
+    (current-balance (get balance user-reward))
+  )
+    (if (<= amount current-balance)
+      (begin
+        (map-set user-rewards
+          { user: tx-sender }
+          { balance: (- current-balance amount) }
+        )
+        (as-contract (stx-transfer? amount tx-sender (as-contract tx-sender)))
+      )
+      err-insufficient-balance
+    )
+  )
+)
+
+;; Function to add funds to the contract (only contract owner can add funds)
+(define-public (add-funds (amount uint))
+  (if (is-eq tx-sender contract-owner)
+    (stx-transfer? amount tx-sender (as-contract tx-sender))
+    err-unauthorized
+  )
+)
+
+;; Read-only functions
+
+;; Get the report status for a product
+(define-read-only (get-report-status (product-id (string-ascii 64)))
+  (map-get? reports { product-id: product-id })
+)
+
+;; Get the reward balance for a user
+(define-read-only (get-reward-balance (user principal))
+  (default-to { balance: u0 } (map-get? user-rewards { user: user }))
+)
+
+;; Get the contract balance
+(define-read-only (get-contract-balance)
+  (stx-get-balance (as-contract tx-sender))
+)

--- a/secure-stamp/tests/counterfeit-reporter.test.ts
+++ b/secure-stamp/tests/counterfeit-reporter.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Counterfeit Reporter Contract

## Overview

The **Counterfeit Reporter Contract** is a smart contract built on the Stacks blockchain designed to enable users to report counterfeit products, verify those reports, and claim rewards for verified reports. The contract allows a reward of 0.1 STX to be claimed by the reporter of a verified counterfeit product. The contract owner has additional administrative privileges to verify reports, add funds to the contract, and manage the balance of the contract.

## Features

- **Report Counterfeit Products**: Users can report counterfeit products by providing a product ID.
- **Verify Reports**: The contract owner can verify reports of counterfeit products.
- **Claim Rewards**: Users can claim a reward of 0.1 STX once their report is verified.
- **Withdraw Rewards**: Users can withdraw their accumulated rewards to their account.
- **Admin Functions**: The contract owner can add funds to the contract to ensure rewards are available.

## Contract Details

### Constants

- `contract-owner`: The principal address of the contract owner (admin).
- `reward-amount`: The reward given to users for a verified counterfeit report (0.1 STX, equivalent to 100,000 micro-STX).

### Error Codes

- `err-unauthorized`: Raised when an unauthorized user attempts an action that requires administrative privileges.
- `err-already-reported`: Raised when a product has already been reported.
- `err-not-reported`: Raised when an attempt is made to verify a report that doesn't exist.
- `err-already-verified`: Raised when a report has already been verified.
- `err-not-verified`: Raised when an attempt is made to claim a reward for a non-verified report.
- `err-already-claimed`: Raised when a reward has already been claimed for a verified report.
- `err-insufficient-balance`: Raised when a user attempts to withdraw more rewards than their current balance.

### Data Maps

- **reports**: A map where each key is a `product-id` (a 64-character string), and the value contains the `reporter`, `verified` status, and `claimed` status.
- **user-rewards**: A map where each key is a user principal, and the value contains the user's reward balance in micro-STX.

### Functions

#### Public Functions

- **report-counterfeit**: 
  - *Parameters*: `product-id` (string)
  - Users can report a counterfeit product by providing a product ID. If the product has already been reported, the function will return an error.
  
- **verify-report**: 
  - *Parameters*: `product-id` (string)
  - Only the contract owner can verify a report. If the report is already verified, an error is returned.

- **claim-reward**: 
  - *Parameters*: `product-id` (string)
  - Users can claim a reward for a verified report. If the report is not verified or has already been claimed, the user will receive an error.
  
- **withdraw-rewards**: 
  - *Parameters*: `amount` (uint)
  - Users can withdraw their reward balance up to the specified amount. If the user has insufficient balance, an error will be returned.

- **add-funds**: 
  - *Parameters*: `amount` (uint)
  - Only the contract owner can add funds to the contract to ensure that rewards can be paid out.

#### Read-Only Functions

- **get-report-status**: 
  - *Parameters*: `product-id` (string)
  - Returns the status of a report for the given product ID, including the reporter's principal, verification status, and whether the reward has been claimed.

- **get-reward-balance**: 
  - *Parameters*: `user` (principal)
  - Returns the reward balance of a specified user.

- **get-contract-balance**: 
  - *Returns*: The current balance of the contract, in STX.

## Usage

### Reporting a Counterfeit Product
To report a counterfeit product, a user needs to call the `report-counterfeit` function and provide a product ID (64-character string). The contract will store the report and mark it as unverified and unclaimed.

### Verifying a Report
Only the contract owner can verify counterfeit reports. The owner can call the `verify-report` function and pass the product ID to mark the report as verified. Once verified, users can claim their rewards.

### Claiming a Reward
Once a product report has been verified, the reporter can call the `claim-reward` function to claim the 0.1 STX reward. If the reward has already been claimed or the report is not verified, the user will receive an error.

### Withdrawing Rewards
Users can withdraw their rewards by calling the `withdraw-rewards` function and specifying the amount to withdraw. The user can withdraw up to the available balance in their account.

### Adding Funds to the Contract
The contract owner can ensure there are enough funds to pay rewards by calling the `add-funds` function, which adds the specified amount of STX to the contract's balance.

## Security Considerations

- Only the contract owner has the ability to verify reports and add funds to the contract.
- Users are only able to claim rewards for reports they have created and that have been verified.
- Rewards can only be withdrawn by users who have a sufficient balance.

## Conclusion

This contract provides a simple but effective mechanism for managing counterfeit product reports, verifying them, and rewarding users for their efforts in identifying counterfeit goods. The functionality is designed to be extensible and secure, with clear error codes and administrative privileges for the contract owner.